### PR TITLE
Updated default value of ntp_timezone: Etc/UTC

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ntp_enabled: true
-ntp_timezone: America/Chicago
+ntp_timezone: Etc/UTC
 
 ntp_manage_config: false
 ntp_servers:


### PR DESCRIPTION
Changed the defaults/main.yml option ntp_timezone: Etc/UTC for more universal compatibility.