### PR TITLE
add become to tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
  - name: restart ntp
    service: "name={{ ntp_daemon }} state=restarted"
    when: ntp_enabled
+   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
     dest: /etc/localtime
     state: link
     force: yes
+  become: true
 
 # Debian family OSes also have an /etc/timezone file.
 - name: Set timezone in /etc/timezone file.
@@ -16,18 +17,22 @@
     dest: /etc/timezone
     force: yes
   when: ansible_os_family == 'Debian'
+  become: true
 
 - name: Install NTP (RedHat).
   yum: name=ntp state=installed
   when: ansible_os_family == 'RedHat'
+  become: true
 
 - name: Install NTP (Debian).
   apt: name=ntp state=installed
   when: ansible_os_family == 'Debian'
+  become: true
 
 - name: Install NTP (FreeBSD).
   pkgng: name=ntp state=present
   when: ansible_os_family == 'FreeBSD'
+  become: true
 
 - name: Ensure NTP is running and enabled as configured.
   service:
@@ -35,6 +40,7 @@
     state: started
     enabled: yes
   when: ntp_enabled
+  become: true
 
 - name: Ensure NTP is stopped and disabled as configured.
   service:
@@ -42,8 +48,10 @@
     state: stopped
     enabled: no
   when: not ntp_enabled
+  become: true
 
 - name: Generate ntp.conf file
   template: src=ntp.conf.j2 dest=/etc/ntp.conf
   notify: restart ntp
   when: ntp_manage_config
+  become: true


### PR DESCRIPTION
Fixes #12 by adding `become: true` to tasks that manage global configs and manage the ntp service.
