### PR TITLE
FreeBSD comes with tzata in the base install, there is no package tzdata

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,14 @@
 
 - name: Ensure NTP-related packages are installed.
   package:
-    name: "{{ item }}"
+    name: ntp
     state: present
-  with_items:
-    - ntp
-    - tzdata
+
+- name: Ensure tzdata package is installed (Linux).
+  package:
+    name: tzdata
+    state: present
+  when: ansible_system == "Linux"
 
 - include: clock-rhel-6.yml
   when: ansible_os_family == 'RedHat' and ansible_distribution_version.split('.')[0] == '6'


### PR DESCRIPTION
Though FreeBSD is not officially supported this role works quite fine with FreeBSD11. Unfortunately the fix for issue #33 changed that, as the role now errors out on FreeBSD, as there is no tzdata package.

This simply makes the installation of tzdata dependent on the target being 'ansible_system == "Linux"', which makes it work again.
