### PR TITLE
Restart crond when timezone is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Set the timezone for your server.
 
 Set to true to allow this role to manage the NTP configuration file (`/etc/ntp.conf`).
 
-    ntp_cron_daemon: "{{ ntp_default_os_cron }}"
+    ntp_cron_daemon: "{{ ntp_default_os_cron }}" 
 
 It is recommended to restart crond after changing the timezone. By default, cron service name is auto-detected but you can force it or set to empty to disable this behaviour
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Set the timezone for your server.
 
 Set to true to allow this role to manage the NTP configuration file (`/etc/ntp.conf`).
 
+    ntp_cron_daemon: "{{ ntp_default_os_cron }}"
+
+It is recommended to restart crond after changing the timezone. By default, cron service name is auto-detected but you can force it or set to empty to disable this behaviour
+
     ntp_area: ''
 
 Set the [NTP Pool Area](http://support.ntp.org/bin/view/Servers/NTPPoolServers) to use. Defaults to none, which uses the worldwide pool.
@@ -41,6 +45,7 @@ Specify the NTP servers you'd like to use. Only takes effect if you allow this r
       - "::1"
 
 Restrict NTP access to these hosts; loopback only, by default.
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ ntp_servers:
 ntp_restrict:
   - "127.0.0.1"
   - "::1"
+
+ntp_cron_daemon: "{{ ntp_default_os_cron }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,12 @@
     name: "{{ ntp_daemon }}"
     state: restarted
   when: ntp_enabled
+
+- name: restart cron
+  service:
+    name: "{{ ntp_cron_daemon }}"
+    state: restarted
+  when:
+    - ntp_cron_daemon | length > 0
+    - ansible_facts.services[ntp_cron_daemon] is defined
+    - ansible_facts.services[ntp_cron_daemon].state == 'running'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Populate service facts
+  service_facts: {}
+  when: ntp_cron_daemon | length > 0
+
 - name: Ensure NTP-related packages are installed.
   package:
     name: ntp
@@ -19,6 +23,7 @@
 - name: Set timezone
   timezone:
     name: "{{ ntp_timezone }}"
+  notify: restart cron
 
 - name: Ensure NTP is running and enabled as configured.
   service:

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -2,3 +2,4 @@
 ntp_daemon: ntpd
 ntp_tzdata_package: tzdata
 ntp_driftfile: /var/lib/ntp/drift
+ntp_default_os_cron: cronie

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,4 @@
 ntp_daemon: ntp
 ntp_tzdata_package: tzdata
 ntp_driftfile: /var/lib/ntp/drift
+ntp_default_os_cron: cron

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -2,3 +2,4 @@
 ntp_daemon: ntpd
 ntp_tzdata_package: tzdata
 ntp_driftfile: /var/lib/ntp/drift
+ntp_default_os_cron: cron

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,4 @@
 ntp_daemon: ntpd
 ntp_tzdata_package: tzdata
 ntp_driftfile: /var/lib/ntp/drift
+ntp_default_os_cron: crond

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -2,3 +2,4 @@
 ntp_daemon: ntpd
 ntp_tzdata_package: timezone
 ntp_driftfile: /var/lib/ntp/drift/ntp.drift
+ntp_default_os_cron: cron


### PR DESCRIPTION
As mentioned in isse #15 , as per https://docs.ansible.com/ansible/timezone_module.html#synopsis, it is recommended to restart crond if the timezone is changed.

This fix detect if cron service is running and then restarts it if needed.