### PR TITLE
Added vars for Sangoma FreePBX distribution (copied from RedHat)

### DIFF
--- a/vars/Sangoma.yml
+++ b/vars/Sangoma.yml
@@ -1,0 +1,4 @@
+---
+ntp_daemon: ntpd
+ntp_tzdata_package: tzdata
+ntp_driftfile: /var/lib/ntp/drift


### PR DESCRIPTION
Sangoma FreePBX is a free user-interface around asterisk. It is running on a RHEL clone, so I copied the redhat configuration for Sangoma.