### PR TITLE
Custom ntp_servers list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,11 +7,6 @@ ntp_manage_config: false
 # NTP server area configuration (leave empty for 'Worldwide').
 # See: http://support.ntp.org/bin/view/Servers/NTPPoolServers
 ntp_area: ''
-ntp_servers:
-  - "0{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org iburst"
-  - "1{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org iburst"
-  - "2{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org iburst"
-  - "3{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org iburst"
 
 ntp_restrict:
   - "127.0.0.1"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,15 @@
     enabled: false
   when: not (ntp_enabled | bool)
 
+- name: Generate servers list if not specified
+  set_fact:
+    ntp_servers:
+      - "0{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org"
+      - "1{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org"
+      - "2{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org"
+      - "3{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org"
+  when: ntp_servers is not defined
+
 - name: Generate ntp.conf file
   template:
     src: ntp.conf.j2

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -16,7 +16,7 @@ filegen clockstats file clockstats type day enable
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 {% for item in ntp_servers %}
-server {{ item }}
+server {{ item }} iburst
 {% endfor %}
 
 # Permit time synchronization with our time source, but do not


### PR DESCRIPTION
Added the ability for users to specify a ntp_servers list instead of using the default pool.ntp.org server list.