### PR TITLE
Disable systemd-timesyncd if running

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,16 @@
   timezone:
     name: "{{ ntp_timezone }}"
 
+- name: Populate service facts
+  service_facts:
+
+- name: Disable systemd-timesyncd
+  service:
+    name: systemd-timesyncd.service
+    enabled: false
+    state: stopped
+  when: ntp_enabled | bool and "systemd-timesyncd.service" in services
+
 - name: Ensure NTP is running and enabled as configured.
   service:
     name: "{{ ntp_daemon }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,12 +23,14 @@
 - name: Populate service facts
   service_facts:
 
-- name: Disable systemd-timesyncd
+- name: Disable systemd-timesyncd if it's running but ntp is enabled.
   service:
     name: systemd-timesyncd.service
     enabled: false
     state: stopped
-  when: ntp_enabled | bool and "systemd-timesyncd.service" in services
+  when:
+  - ntp_enabled | bool
+  - '"systemd-timesyncd.service" in services'
 
 - name: Ensure NTP is running and enabled as configured.
   service:


### PR DESCRIPTION
This prevents race condition during system boot where the service which starts the latest wins.