### PR TITLE
Fix ntp_daemon variable initialization

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,11 @@
     ntp_config_file: "{{ __ntp_config_file }}"
   when: ntp_config_file is not defined
 
+- name: Set the ntp_daemon variable.
+  set_fact:
+    ntp_daemon: "{{ __ntp_daemon }}"
+  when: ntp_daemon is not defined
+
 - name: Ensure NTP package is installed.
   package:
     name: "{{ ntp_package }}"

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,5 +1,5 @@
 ---
-ntp_daemon: ntpd
+__ntp_daemon: ntpd
 ntp_tzdata_package: tzdata
 __ntp_package: ntp
 __ntp_config_file: /etc/ntp.conf

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,5 @@
 ---
-ntp_daemon: ntp
+__ntp_daemon: ntp
 ntp_tzdata_package: tzdata
 __ntp_package: ntp
 __ntp_config_file: /etc/ntp.conf

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,5 +1,5 @@
 ---
-ntp_daemon: ntpd
+__ntp_daemon: ntpd
 ntp_tzdata_package: tzdata
 __ntp_package: ntp
 __ntp_config_file: /etc/ntp.conf

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,5 +1,5 @@
 ---
-ntp_daemon: ntpd
+__ntp_daemon: ntpd
 ntp_tzdata_package: tzdata
 __ntp_package: ntp
 __ntp_config_file: /etc/ntp.conf

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-ntp_daemon: chronyd
+__ntp_daemon: chronyd
 ntp_tzdata_package: tzdata
 __ntp_package: chrony
 __ntp_config_file: /etc/chrony.conf

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,5 +1,5 @@
 ---
-ntp_daemon: ntpd
+__ntp_daemon: ntpd
 ntp_tzdata_package: timezone
 __ntp_package: ntp
 __ntp_config_file: /etc/ntp.conf


### PR DESCRIPTION
Fixed issue where you could not change the ntp_daemon to ntp when it defaults to chrony though import vars from the system includes.