### PR TITLE
use pool directive over server

### DIFF
--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -23,7 +23,7 @@ tinker panic 0
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 {% for item in ntp_servers %}
-server {{ item }}
+pool {{ item }}
 {% endfor %}
 
 # Permit time synchronization with our time source, but do not


### PR DESCRIPTION
In NTP 4.2.6 the `pool` directive was introduced: http://doc.ntp.org/4.2.6/manyopt.html

The main advantage of using `pool` is that ntpd is able to update IP addresses from the specified pool dynamically, discarding unreachable servers and adding new ones on the fly. On the other hand with `server` ntpd uses the IP addresses returned at start-up and doesn't do anything to rectify unreachable addresses until ntpd is restarted.