### PR TITLE
remove iburst parameter from template

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -2,7 +2,7 @@
 
 # These servers were defined in the installation:
 {% for server in ntp_servers %}
-server {{ server }} iburst
+server {{ server }}
 {% endfor %}
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).


### PR DESCRIPTION
this parameter should be part of the strings provides via nts_servers variable. Thats liek it is int the ntpd.conf template and makes sense.