### PR TITLE
allow pool associations

### DIFF
--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -30,6 +30,9 @@ pool {{ item }}
 # permit the source to query or modify the service on this system.
 restrict default nomodify notrap nopeer noquery
 
+# Allow pool associations
+restrict source nomodify notrap noquery
+
 # Permit all access over the loopback interface.  This could
 # be tightened as well, but to do so would effect some of
 # the administrative functions.


### PR DESCRIPTION
the pool directive was introduced in https://github.com/geerlingguy/ansible-role-ntp/pull/77
in order to work properly, the nopeer restriction should be allowed for sources
See further information:
https://github.com/geerlingguy/ansible-role-ntp/pull/77
https://bugs.ntp.org/show_bug.cgi?id=2657