### PR TITLE
pool/server directives switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Set the [NTP Pool Area](http://support.ntp.org/bin/view/Servers/NTPPoolServers) 
 
 Specify the NTP servers you'd like to use. Only takes effect if you allow this role to manage NTP's configuration, by setting `ntp_manage_config` to `True`.
 
+    ntp_no_pool: true
+
+Using 'server' directive for ntp_servers instead of 'pool'. Suitable for specific/old servers which cannot respond properly as pool.
+
     ntp_restrict:
       - "127.0.0.1"
       - "::1"

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -23,7 +23,11 @@ tinker panic 0
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 {% for item in ntp_servers %}
+{% if ntp_no_pool is true %}
+server {{ item }}
+{% else %}
 pool {{ item }}
+{% endif %}
 {% endfor %}
 
 # Permit time synchronization with our time source, but do not


### PR DESCRIPTION
Ability to switch back from 'pool' to 'server' directive. Suitable for specific/old servers which cannot respond properly as pool.