### PR TITLE
added config option for setting the server/pool keyword in the ntp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The default NTP driftfile should be correct for your distribution, but there are
 
     ntp_area: ''
 
+Sets the keyword used for servers in the NTP configuration file. The keyword pool is a good choice when DNS resolve is an option, if not you should use server instead.
+
+    ntp_server_keyword: pool
+
 Set the [NTP Pool Area](http://support.ntp.org/bin/view/Servers/NTPPoolServers) to use. Defaults to none, which uses the worldwide pool.
 
     ntp_servers:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ ntp_manage_config: false
 # NTP server area configuration (leave empty for 'Worldwide').
 # See: http://support.ntp.org/bin/view/Servers/NTPPoolServers
 ntp_area: ''
+ntp_server_keyword: pool
 ntp_servers:
   - "0{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org iburst"
   - "1{{ '.' + ntp_area if ntp_area else '' }}.pool.ntp.org iburst"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,5 @@ ntp_restrict:
 ntp_cron_handler_enabled: false
 
 ntp_tinker_panic: false
+
+ntp_skip_install: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,9 @@
 - name: Set the ntp_package variable.
   set_fact:
     ntp_package: "{{ __ntp_package }}"
-  when: ntp_package is not defined
+  when:
+    - ntp_package is not defined
+    - not ntp_skip_install
 
 - name: Set the ntp_config_file variable.
   set_fact:
@@ -32,12 +34,15 @@
   package:
     name: "{{ ntp_package }}"
     state: present
+  when: not ntp_skip_install
 
 - name: Ensure tzdata package is installed (Linux).
   package:
     name: "{{ ntp_tzdata_package }}"
     state: present
-  when: ansible_system == "Linux"
+  when:
+    - ansible_system == "Linux"
+    - not ntp_skip_install
 
 - include_tasks: clock-rhel-6.yml
   when:

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -23,7 +23,7 @@ tinker panic 0
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 {% for item in ntp_servers %}
-pool {{ item }}
+{{ ntp_server_keyword }} {{ item }}
 {% endfor %}
 
 # Permit time synchronization with our time source, but do not


### PR DESCRIPTION
in case the NTP server is only known by IP and there is no DNS allowed in the network the `server` keyword should be used instead of `pool`.