### PR TITLE
Fix check mode for ansible 2.10+

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,10 +3,14 @@
   service:
     name: "{{ ntp_daemon }}"
     state: restarted
-  when: ntp_enabled | bool
+  when:
+    - not (ansible_check_mode | bool)
+    - ntp_enabled | bool
 
 - name: restart cron
   service:
     name: "{{ ntp_cron_daemon }}"
     state: restarted
-  when: ntp_cron_handler_enabled | bool
+  when:
+    - not (ansible_check_mode | bool)
+    - ntp_cron_handler_enabled | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,20 +60,25 @@
   when:
     - ntp_enabled | bool
     - '"systemd-timesyncd.service" in services'
+    - not (ansible_check_mode | bool)
 
 - name: Ensure NTP is running and enabled as configured.
   service:
     name: "{{ ntp_daemon }}"
     state: started
     enabled: true
-  when: ntp_enabled | bool
+  when:
+    - ntp_enabled | bool
+    - not (ansible_check_mode | bool)
 
 - name: Ensure NTP is stopped and disabled as configured.
   service:
     name: "{{ ntp_daemon }}"
     state: stopped
     enabled: false
-  when: not (ntp_enabled | bool)
+  when:
+    - not (ntp_enabled | bool)
+    - not (ansible_check_mode | bool)
 
 - name: Generate ntp configuration file.
   template:


### PR DESCRIPTION
As of ansible 2.10, it is necessary to skip service restarts in check mode to
avoid failures.

See https://github.com/ansible/ansible/issues/72721 for more details.