### PR TITLE
Ensure the configuration file is updated before attempting to start the service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,13 +61,6 @@
     - ntp_enabled | bool
     - '"systemd-timesyncd.service" in services'
 
-- name: Ensure NTP is running and enabled as configured.
-  service:
-    name: "{{ ntp_daemon }}"
-    state: started
-    enabled: true
-  when: ntp_enabled | bool
-
 - name: Ensure NTP is stopped and disabled as configured.
   service:
     name: "{{ ntp_daemon }}"
@@ -82,3 +75,10 @@
     mode: 0644
   notify: restart ntp
   when: ntp_manage_config | bool
+
+- name: Ensure NTP is running and enabled as configured.
+  service:
+    name: "{{ ntp_daemon }}"
+    state: started
+    enabled: true
+  when: ntp_enabled | bool


### PR DESCRIPTION
Fixes issue #76 .

The issue was closed due to inactivity so I'm hoping that a pull request will make it easier to get this fixed.
This change ensures that if the service is stopped due to a configuration error it can be started after the error has been resolved.