### PR TITLE
Fix tzdata package to always be up-to-date

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,8 +30,9 @@
 - name: Ensure tzdata package is installed (Linux).
   package:
     name: "{{ ntp_tzdata_package }}"
-    state: present
+    state: latest
   when: ansible_system == "Linux"
+  tags: ['skip_ansible_lint']
 
 - name: Set timezone.
   timezone:


### PR DESCRIPTION
Generally we don't want to use the latest
package version, but in the case of tzdata
this is exactly the case.