### PR TITLE
Added {{ ntp_restrict }} to allow lines in chrony.conf.j2 to designat…

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -26,6 +26,9 @@ rtcsync
 
 # Allow NTP client access from local network.
 #allow 192.168.0.0/16
+{% for item in ntp_restrict %}
+allow {{ item }}
+{% endfor %}
 
 # Serve time even if not synchronized to a time source.
 #local stratum 10


### PR DESCRIPTION
…e NTP clients which are allowed to access the chronyd NTP server. This makes ntp_restrict variable to take effect on chrony.conf.