### PR TITLE
Added support for specifying an alternate logfile to use instead of the syslog facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Whether to restart the cron daemon after the timezone has changed.
 
 Enable tinker panic, which is useful when running NTP in a VM.
 
+    ntp_logfile: "/var/log/ntp"
+
+Define an alternate logfile to be used instead of the syslog facility.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,5 @@ ntp_restrict:
 ntp_cron_handler_enabled: false
 
 ntp_tinker_panic: false
+
+# ntp_logfile: /var/log/ntp

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -76,3 +76,8 @@ disable monitor
 # next lines. Please do this only if you trust everybody on the network!
 #disable auth
 #broadcastclient
+
+{% if ntp_logfile is defined %}
+# Specify alternate logfile
+logfile {{ ntp_logfile }}
+{% endif %}


### PR DESCRIPTION
I needed support for specifying an alternate logfile to use instead of the syslog facility, therefore I added this funktion to my own fork and would like to contribute it to your role to be able to use that role again and not my own fork. 