### PR TITLE
Restart ntp service if stopped unintentionally

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,29 @@
     enabled: true
   when: ntp_enabled | bool
 
+- name: Make sure NTP is restarted if stopped unintentionally.
+  block:
+    - name: Create directory for ntp service override.
+      file:
+        path: "/etc/systemd/system/ntp.service.d"
+        state: directory
+        mode: '0755'
+    - name: Make ntp service restart if the process exits for any reason.
+      copy:
+        content: |
+          [Service]
+          Restart=always
+        dest: "/etc/systemd/system/ntp.service.d/override.conf"
+        mode: '0644'
+      register: ntp_service_config_override
+    - name: Reload daemon to reread the configs
+      systemd:
+        daemon_reload: true
+      when: ntp_service_config_override is changed
+  when:
+    - ntp_enabled | bool
+    - '"systemd-timesyncd.service" in services'
+
 - name: Ensure NTP is stopped and disabled as configured.
   service:
     name: "{{ ntp_daemon }}"


### PR DESCRIPTION
The primary use case for this change is virtual machines running on laptops. With the default configuration if a laptop is put to sleep for > 1000 seconds so that the clock in the virtual machine delays then ntp daemon stops and never starts again.

From man ntpd:

>     Normally, ntpd exits with a message to the system log if the offset
>     exceeds the panic threshold, which is 1000 s by default. This option
>     allows the time to be set to any value without restriction; however,
>     this can happen *only once*. If the threshold is exceeded after that,
>     *ntpd will exit with a message to the system log*. This option can be
>     used with the -q and -x options.  See the tinker configuration file
>     directive for other options.