### PR TITLE
 enabled backups for old config versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,7 @@
 
 - name: Generate ntp configuration file.
   template:
+    backup: yes
     src: "{{ ntp_config_file | basename }}.j2"
     dest: "{{ ntp_config_file }}"
     mode: 0644


### PR DESCRIPTION
creates a backup of the former config file before templating