### PR TITLE
ntp drift file for Debian

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,5 +3,5 @@ __ntp_daemon: ntp
 ntp_tzdata_package: tzdata
 __ntp_package: ntp
 __ntp_config_file: /etc/ntp.conf
-__ntp_driftfile: /var/lib/ntp/drift
+__ntp_driftfile: /var/lib/ntp/ntp.drift
 ntp_cron_daemon: cron


### PR DESCRIPTION
is /var/lib/ntp/ntp.drift, checked on Debian 8 + 9 + 10 ...