### PR TITLE
fix: Debian 10 issue with systemd-timesyncd.service "status" key not present on old Ansible installs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
   when:
     - ntp_enabled | bool
     - '"systemd-timesyncd.service" in services'
+    - '"status" in services["systemd-timesyncd.service"]'
     - services["systemd-timesyncd.service"]["status"] != "not-found"
 
 - name: Ensure NTP is running and enabled as configured.


### PR DESCRIPTION
Target Debian 10, super old Ansible install:
`ansible==2.5.15`

Issue:

```
TASK [geerlingguy.ntp : Disable systemd-timesyncd if it's running but ntp is enabled.] ************************************************************************************************************************************************************************************************************************
fatal: [textbookweb-client-hetzner]: FAILED! => {"msg": "The conditional check 'services[\"systemd-timesyncd.service\"][\"status\"] != \"not-found\"' failed. The error was: error while evaluating conditional (services[\"systemd-timesyncd.service\"][\"status\"] != \"not-found\"): 'dict object' has no attribute 'status'\n\nThe error appears to have been in '/home/dev/ansible/.galaxy/geerlingguy.ntp/tasks/main.yml': line 44, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Disable systemd-timesyncd if it's running but ntp is enabled.\n  ^ here\n"}
```

Fix attached.