### PR TITLE
Adapt the chrony config template to use pool instead of server directive

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,8 +1,8 @@
 # {{ ansible_managed }}
 
 # These servers were defined in the installation:
-{% for server in ntp_servers %}
-server {{ server }}
+{%or server in ntp_servers %}
+pool {{ server }}
 {% endfor %}
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # These servers were defined in the installation:
-{%or server in ntp_servers %}
+{% for server in ntp_servers %}
 pool {{ server }}
 {% endfor %}
 # Use public servers from the pool.ntp.org project.


### PR DESCRIPTION
Similar to #77 chrony supports the `pool` directive since version 2.0 (see [chrony-2.0 released](https://chrony.tuxfamily.org/news.html#_27_apr_2015_chrony_2_0_released)). This version is quite old (2015) and hence the directive should be supported by all major OS.

This change will ensure, that both ntp and chrony are able to consume the configured ntp_servers as pool servers. Currently, there is a difference when the specified DNS name specified as `server` gets resolved to multiple IPs. With the `pool` directive all can be utilized (as already specified for ntp).