### PR TITLE
Allow to override the default templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Whether to restart the cron daemon after the timezone has changed.
 
 Enable tinker panic, which is useful when running NTP in a VM.
 
+## Not satisfied with the bundled templates? Make your own !
+
+The templates packaged with this role are intended to be very generic.
+
+If the default template doesn't suit your needs, you can replace it with your own. What do you need to do:
+* create a `templates` directory at the same level as your playbook
+* create a `templates\myntp.conf.j2` file (just choose a different name from the default template)
+* in your playbook set the var `ntp_config_file_template: myntp.conf.j2`
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,5 @@ ntp_restrict:
 ntp_cron_handler_enabled: false
 
 ntp_tinker_panic: false
+
+ntp_config_file_template: "{{ ntp_config_file | basename }}.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name: Generate ntp configuration file.
   template:
-    src: "{{ ntp_config_file | basename }}.j2"
+    src: "{{ ntp_config_file_template }}"
     dest: "{{ ntp_config_file }}"
     mode: 0644
   notify: restart ntp


### PR DESCRIPTION
This is an implementation proposition for https://github.com/geerlingguy/ansible-role-ntp

It does not change the default role's behaviour and allows user to override the default provided template with their own.