### PR TITLE
rocky linux support

### DIFF
--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,7 @@
+---
+__ntp_daemon: chronyd
+ntp_tzdata_package: tzdata
+__ntp_package: chrony
+__ntp_config_file: /etc/chrony.conf
+__ntp_driftfile: /var/lib/ntp/drift
+ntp_cron_daemon: crond


### PR DESCRIPTION
It seems Rockylinux is expecting the Rocky.yml file in variables but it is not found. 


```
fatal: [rockylinux8]: FAILED! => {"ansible_facts": {}, "ansible_included_var_files": [], "changed": false, "message": "Could not find or access 'Rocky.yml'\nSearched in:\n\t/Users/***/.ansible/roles/geerlingguy.ntp/vars/Rocky.yml\n\t/Users/***/.ansible/roles/geerlingguy.ntp/Rocky.yml\n\t/Users/***/.ansible/roles/geerlingguy.ntp/tasks/vars/Rocky.yml\n\t/Users/***/.ansible/roles/geerlingguy.ntp/tasks/Rocky.yml\n\t/Users/***/Downloads/galaxymoleculetest/molecule/default/vars/Rocky.yml\n\t/Users/***/Downloads/galaxymoleculetest/molecule/default/Rocky.yml on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```

I have added the file for Rockylinux under the vars directory.