### PR TITLE
allow errors in dry-run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,7 @@
     state: started
     enabled: true
   when: ntp_enabled | bool
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure NTP is stopped and disabled as configured.
   service:
@@ -64,6 +65,7 @@
     state: stopped
     enabled: false
   when: not (ntp_enabled | bool)
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Generate ntp configuration file.
   template:


### PR DESCRIPTION
If I want to make a dry-run on a new machine there are some errors thrown and the playbook is stopping. I added to ignore the errors in check-mode, so that the whole play will run