### PR TITLE
Allow for multi-line ansible_managed values

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 # These servers were defined in the installation:
 {% for server in ntp_servers %}


### PR DESCRIPTION
When using a multi-line ansible_managed, the current template will make chronyd not start since not all lines are commented. This will fix that.