### PR TITLE
Update OS-specific variables in NTP role to have major version check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: Include OS-specific variables.
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_facts['os_family'] + '_' + ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ ansible_facts['os_family'] }}.yml"
 
 - name: Set the ntp_driftfile variable.
   set_fact:

--- a/vars/Debian_12.yml
+++ b/vars/Debian_12.yml
@@ -1,0 +1,6 @@
+__ntp_daemon: ntpsec
+ntp_tzdata_package: tzdata
+__ntp_package: ntpsec
+__ntp_config_file: /etc/ntpsec/ntp.conf
+__ntp_driftfile: /var/lib/ntpsec/ntp.drift
+ntp_cron_daemon: cron


### PR DESCRIPTION
## Pull Request Resume

Author: GreenITSolutions

Date: 2023/10/18

Pull Request Description:
This pull request aims to enhance the OS-specific variable inclusion in the Ansible role to provide better support for different OS distributions and **majors versions**. It replaces the existing static variable inclusion with a dynamic approach, making the role more adaptable. Additionally, it adds a specific file for **Debian 12**, improving the support for this particular distribution.

Please feel free to review and provide feedback on the proposed changes. Your input is highly appreciated !