### PR TITLE
Added ntp_restrict to chrony.conf

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -26,6 +26,9 @@ rtcsync
 
 # Allow NTP client access from local network.
 #allow 192.168.0.0/16
+{% for item in ntp_restrict %}
+allow {{ item }}
+{% endfor %}
 
 # Serve time even if not synchronized to a time source.
 #local stratum 10


### PR DESCRIPTION
There was already a `ntp_restrict` variable, but it was only used in `ntp.conf.j2`. This will add it to `chrony.conf.j2` as well.