### PR TITLE
refactor: Modernize role for ansible-core 2.12+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 */__pycache__
 *.pyc
 .cache
-
+.ansible

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
-- name: restart ntp
-  service:
+- name: Restart ntp
+  ansible.builtin.service:
     name: "{{ ntp_daemon }}"
     state: restarted
   when: ntp_enabled | bool
 
-- name: restart cron
-  service:
+- name: Restart cron
+  ansible.builtin.service:
     name: "{{ ntp_cron_daemon }}"
     state: restarted
   when: ntp_cron_handler_enabled | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: NTP installation and configuration for Linux.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.10
+  min_ansible_version: "2.12"
   platforms:
     - name: Fedora
       versions:
@@ -21,10 +21,10 @@ galaxy_info:
     - name: FreeBSD
       versions:
         - all
-    - name: Suse
+    - name: SLES
       versions:
         - all
-    - name: Archlinux
+    - name: ArchLinux
       versions:
         - all
   galaxy_tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,62 +1,62 @@
 ---
 - name: Include OS-specific variables.
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_facts.distribution + '-' + ansible_facts['distribution_version'] }}.yml"
     - "{{ ansible_facts.os_family + '-' + ansible_facts['distribution_major_version'] }}.yml"
     - "{{ ansible_facts.os_family }}.yml"
 
 - name: Set the ntp_driftfile variable.
-  set_fact:
+  ansible.builtin.set_fact:
     ntp_driftfile: "{{ __ntp_driftfile }}"
   when: ntp_driftfile is not defined
 
 - name: Set the ntp_package variable.
-  set_fact:
+  ansible.builtin.set_fact:
     ntp_package: "{{ __ntp_package }}"
   when: ntp_package is not defined
 
 - name: Set the ntp_config_file variable.
-  set_fact:
+  ansible.builtin.set_fact:
     ntp_config_file: "{{ __ntp_config_file }}"
   when: ntp_config_file is not defined
 
 - name: Set the ntp_daemon variable.
-  set_fact:
+  ansible.builtin.set_fact:
     ntp_daemon: "{{ __ntp_daemon }}"
   when: ntp_daemon is not defined
 
 - name: Ensure NTP package is installed.
-  package:
+  ansible.builtin.package:
     name: "{{ ntp_package }}"
     state: present
 
 - name: Ensure tzdata package is installed (Linux).
-  package:
+  ansible.builtin.package:
     name: "{{ ntp_tzdata_package }}"
     state: present
   when: ansible_facts.system == "Linux"
 
 - name: Set timezone.
-  timezone:
+  community.general.timezone:
     name: "{{ ntp_timezone }}"
-  notify: restart cron
+  notify: Restart cron
 
 - name: Populate service facts.
-  service_facts:
+  ansible.builtin.service_facts:
 
 - name: Disable systemd-timesyncd if it's running but ntp is enabled.
-  service:
+  ansible.builtin.service:
     name: systemd-timesyncd.service
     enabled: false
     state: stopped
   when:
     - ntp_enabled | bool
-    - '"systemd-timesyncd.service" in services'
-    - services["systemd-timesyncd.service"]["status"] != "not-found"
+    - '"systemd-timesyncd.service" in ansible_facts.services'
+    - ansible_facts.services["systemd-timesyncd.service"].status != "not-found"
 
 - name: Ensure NTP is running and enabled as configured.
-  service:
+  ansible.builtin.service:
     name: "{{ ntp_daemon }}"
     state: started
     enabled: true
@@ -64,7 +64,7 @@
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure NTP is stopped and disabled as configured.
-  service:
+  ansible.builtin.service:
     name: "{{ ntp_daemon }}"
     state: stopped
     enabled: false
@@ -72,9 +72,9 @@
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Generate ntp configuration file.
-  template:
+  ansible.builtin.template:
     src: "{{ ntp_config_file | basename }}.j2"
     dest: "{{ ntp_config_file }}"
     mode: 0644
-  notify: restart ntp
+  notify: Restart ntp
   when: ntp_manage_config | bool


### PR DESCRIPTION
Update role to align with ansible-core 2.12+ best practices by using fully qualified collection names (FQCNs) throughout and standardizing fact access patterns. This improves maintainability and ensures compatibility with modern Ansible versions.

Module updates:
* Use ansible.builtin.* FQCN for all core modules
* Replace timezone with community.general.timezone
* Update service facts references to ansible_facts.services
* Standardize handler name capitalization

Metadata improvements:
* Set min_ansible_version to 2.12
* Fix platform names: Suse → SLES, Archlinux → ArchLinux

Development tooling:
* Add .ansible to .gitignore for local ansible collections