### PR TITLE
Use `ansible_facts` instead of `ansible_` prefix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,8 +52,8 @@
     state: stopped
   when:
     - ntp_enabled | bool
-    - '"systemd-timesyncd.service" in services'
-    - services["systemd-timesyncd.service"]["status"] != "not-found"
+    - '"systemd-timesyncd.service" in ansible_facts.services'
+    - ansible_facts.services["systemd-timesyncd.service"]["status"] != "not-found"
 
 - name: Ensure NTP is running and enabled as configured.
   service:


### PR DESCRIPTION
As per the ansible cli output, updated the role to use `ansible_facts`
<img width="1664" height="610" alt="image" src="https://github.com/user-attachments/assets/ca58962f-f044-4496-8b46-c6947ab530ee" />

Links: https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/service_facts_module.html