### PR TITLE
Add ntp_makestep variable for chrony configuration for RHEL/CentOS 7+…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Enable tinker panic, which is useful when running NTP in a VM.
 
 Increase the maximum root distance between the host & the ntp source.
 
+    ntp_makestep: "1.0 3"
+
+Only applies to chrony-based systems (RHEL/CentOS 7+). Has no effect on ntpd-based systems.  The `makestep` directive for chrony. Controls clock stepping behavior — if the offset is larger than the first value (in seconds), the clock will be stepped rather than slewed, but only for the first N updates (second value). Set to `"1.0 -1"` to always step, useful for VMs that may be suspended/resumed with significant drift.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ntp_enabled: true
 ntp_timezone: Etc/UTC
+ntp_makestep: "1.0 3"
 
 # ntp_daemon: [various]
 # ntp_package: ntp

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -12,7 +12,7 @@ driftfile /var/lib/chrony/drift
 
 # Allow the system clock to be stepped in the first three updates
 # if its offset is larger than 1 second.
-makestep 1.0 3
+makestep {{ ntp_makestep }}
 
 # Enable kernel synchronization of the real-time clock (RTC).
 rtcsync


### PR DESCRIPTION
**PR title:** `Add ntp_makestep variable for chrony configuration`

**PR body suggestion:**
```
## Summary
Adds `ntp_makestep` as a configurable variable for the `makestep` 
directive in `chrony.conf`.

## Motivation
The `makestep` value is currently hardcoded as `1.0 3`. While this 
is a sensible default, environments like VMs that can be 
suspended/resumed or snapshotted may need to tune this — for 
example, setting `1.0 -1` to always step the clock regardless of 
update count.

## Changes
- `defaults/main.yml`: Added `ntp_makestep: "1.0 3"`
- `templates/chrony.conf.j2`: Replaced hardcoded value with `{{ ntp_makestep }}`
- `README.md`: Documented the new variable

## Backwards Compatibility
The default value is identical to the previously hardcoded value. 
No existing behavior is changed.