### PR TITLE
add Debian 12 (Bookworm) and Debian 13 (Trixie) support

### DIFF
--- a/vars/Debian-12.yml
+++ b/vars/Debian-12.yml
@@ -1,0 +1,7 @@
+---
+__ntp_daemon: ntpsec
+ntp_tzdata_package: tzdata
+__ntp_package: ntpsec
+__ntp_config_file: /etc/ntpsec/ntp.conf
+__ntp_driftfile: /var/lib/ntpsec/ntp.drift
+ntp_cron_daemon: cron

--- a/vars/Debian-13.yml
+++ b/vars/Debian-13.yml
@@ -1,0 +1,7 @@
+---
+__ntp_daemon: ntpsec
+ntp_tzdata_package: tzdata
+__ntp_package: ntpsec
+__ntp_config_file: /etc/ntpsec/ntp.conf
+__ntp_driftfile: /var/lib/ntpsec/ntp.drift
+ntp_cron_daemon: cron


### PR DESCRIPTION
Both Debian 12 (Bookworm) and Debian 13 (Trixie) replaced the `ntp` package 
with `ntpsec`. Without these vars files the role falls back to `Debian.yml` 
which tries to install the old `ntp` package, causing the installation to fail 
on these platforms.

Added:
- `vars/Debian-12.yml` — uses ntpsec with correct config paths
- `vars/Debian-13.yml` — same as Debian 12, ntpsec is used here too

Tested on Debian 12 (Bookworm) and Debian 13 (Trixie) with Proxmox VE.